### PR TITLE
finish the test .

### DIFF
--- a/main.py
+++ b/main.py
@@ -218,6 +218,7 @@ async def run_adapter():
 
             # 然后初始化后台任务管理器并启动监控
             background_task_manager.register_connection_monitor(discord_client)
+            background_task_manager.register_reaction_event_task(discord_client, message_handler)
             background_task_manager.start_all_tasks()
             logger.info("后台任务管理器已初始化并启动")
 

--- a/src/background_tasks.py
+++ b/src/background_tasks.py
@@ -4,10 +4,11 @@
 
 import asyncio
 from typing import Optional
+import discord
 from discord.ext import tasks
 
 from .logger import logger
-from .config import global_config
+from .config import global_config, is_user_allowed
 
 
 class ConnectionMonitorTask:
@@ -51,11 +52,11 @@ class ConnectionMonitorTask:
                 logger.debug("正在重连中，跳过本次连接状态检查")
                 return
 
-            # 检查连接状态，设置超时保护（增加到10秒）
+            # 检查连接状态，设置超时保护
             try:
-                await asyncio.wait_for(self._check_connection_status(), timeout=10)
+                await asyncio.wait_for(self._check_connection_status(), timeout=30)
             except asyncio.TimeoutError:
-                logger.error("连接状态检测超时（10秒），可能网络存在问题")
+                logger.error("连接状态检测超时，可能网络存在问题")
                 if self.client_manager and not getattr(self.client_manager, 'is_reconnecting', False):
                     logger.warning("触发超时重连")
                     self.client_manager.is_connected = False
@@ -226,6 +227,204 @@ class ConnectionMonitorTask:
         self.start()
 
 
+class ReactionEventTask:
+    """Reaction事件处理任务类
+    
+    负责监听Discord的reaction事件并转发到消息处理器
+    
+    Attributes:
+        client_manager: Discord客户端管理器实例
+        message_handler: 消息处理器实例
+        is_running: 任务运行状态
+    """
+
+    def __init__(self, client_manager, message_handler):
+        """初始化Reaction事件处理任务
+        
+        Args:
+            client_manager: Discord客户端管理器实例
+            message_handler: 消息处理器实例
+        """
+        self.client_manager = client_manager
+        self.message_handler = message_handler
+        self.is_running: bool = False
+        logger.debug("Reaction事件处理任务初始化完成")
+
+    def start(self):
+        """启动reaction事件监听"""
+        if not self.client_manager or not self.client_manager.client:
+            logger.error("Discord客户端未初始化，无法启动reaction事件监听")
+            return
+
+        if self.is_running:
+            logger.warning("Reaction事件监听已在运行")
+            return
+
+        client = self.client_manager.client
+
+        # 仅注册一次事件处理器，防止重复覆盖
+        if not getattr(client, '_reaction_events_registered', False):
+            @client.event
+            async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
+                """监听表情添加事件"""
+                await self._on_raw_reaction_add(payload)
+
+            @client.event
+            async def on_raw_reaction_remove(payload: discord.RawReactionActionEvent):
+                """监听表情移除事件"""
+                await self._on_raw_reaction_remove(payload)
+
+            client._reaction_events_registered = True
+            logger.debug("Reaction事件处理器已注册到Discord客户端")
+        else:
+            logger.debug("Reaction事件处理器已存在，直接启用监听")
+
+        self.is_running = True
+        logger.info("Reaction事件监听已启动")
+
+    async def _on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        """处理表情添加事件
+        
+        Args:
+            payload: Reaction事件数据
+        """
+        try:
+            if not self.is_running:
+                logger.debug("Reaction事件监听已停止，忽略reaction_add事件")
+                return
+
+            client = self.client_manager.client
+            if not client or not client.user:
+                logger.warning("Discord客户端未就绪，忽略reaction_add事件")
+                return
+
+            # 忽略机器人自己的reaction
+            if payload.user_id == client.user.id:
+                logger.debug("忽略机器人自己的reaction")
+                return
+
+            # 获取基本信息
+            guild_id = payload.guild_id
+            channel_id = payload.channel_id
+            user_id = payload.user_id
+
+            # 获取channel对象判断是否为子区
+            channel = client.get_channel(channel_id)
+            if not channel:
+                try:
+                    channel = await client.fetch_channel(channel_id)
+                except (discord.NotFound, discord.Forbidden):
+                    logger.warning(f"无法获取频道 {channel_id}")
+                    return
+                except discord.HTTPException as fetch_error:
+                    logger.error(f"获取频道 {channel_id} 时发生错误: {fetch_error}")
+                    return
+
+            is_thread = isinstance(channel, discord.Thread)
+            thread_id = channel_id if is_thread else None
+
+            # 如果是子区且继承父频道权限
+            if is_thread and global_config.chat.inherit_channel_permissions:
+                parent_channel_id = channel.parent.id if getattr(channel, 'parent', None) else channel_id
+                logger.debug(f"子区reaction继承父频道权限: 子区ID={thread_id}, 父频道ID={parent_channel_id}")
+                check_channel_id = parent_channel_id
+            else:
+                check_channel_id = channel_id
+
+            logger.debug(
+                "Reaction权限检查: 用户ID=%s, 服务器ID=%s, 频道ID=%s, 子区ID=%s",
+                user_id,
+                guild_id,
+                check_channel_id,
+                thread_id,
+            )
+
+            if not is_user_allowed(global_config, user_id, guild_id, check_channel_id, thread_id, is_thread):
+                logger.warning(f"用户 {user_id} 或频道 {check_channel_id} 不在允许列表中，忽略reaction")
+                return
+
+            # 转发到消息处理器
+            logger.debug(f"收到reaction_add事件: 用户={user_id}, 消息={payload.message_id}, emoji={payload.emoji}")
+            await self.message_handler.handle_reaction_event('reaction_add', payload)
+
+        except Exception as e:
+            logger.error(f"处理reaction_add事件时发生错误: {e}")
+            import traceback
+            logger.error(f"错误详情: {traceback.format_exc()}")
+
+    async def _on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        """处理表情移除事件
+        
+        Args:
+            payload: Reaction事件数据
+        """
+        try:
+            if not self.is_running:
+                logger.debug("Reaction事件监听已停止，忽略reaction_remove事件")
+                return
+
+            client = self.client_manager.client
+            if not client or not client.user:
+                logger.warning("Discord客户端未就绪，忽略reaction_remove事件")
+                return
+
+            # 忽略机器人自己的reaction
+            if payload.user_id == client.user.id:
+                logger.debug("忽略机器人自己的reaction")
+                return
+
+            # 获取基本信息
+            guild_id = payload.guild_id
+            channel_id = payload.channel_id
+            user_id = payload.user_id
+
+            # 检查权限
+            channel = client.get_channel(channel_id)
+            if not channel:
+                try:
+                    channel = await client.fetch_channel(channel_id)
+                except (discord.NotFound, discord.Forbidden):
+                    logger.warning(f"无法获取频道 {channel_id}")
+                    return
+                except discord.HTTPException as fetch_error:
+                    logger.error(f"获取频道 {channel_id} 时发生错误: {fetch_error}")
+                    return
+
+            is_thread = isinstance(channel, discord.Thread)
+            thread_id = channel_id if is_thread else None
+
+            # 如果是子区且继承父频道权限
+            if is_thread and global_config.chat.inherit_channel_permissions:
+                parent_channel_id = channel.parent.id if getattr(channel, 'parent', None) else channel_id
+                check_channel_id = parent_channel_id
+            else:
+                check_channel_id = channel_id
+
+            if not is_user_allowed(global_config, user_id, guild_id, check_channel_id, thread_id, is_thread):
+                logger.warning(f"用户 {user_id} 或频道 {check_channel_id} 不在允许列表中，忽略reaction")
+                return
+
+            # 转发到消息处理器
+            logger.debug(f"收到reaction_remove事件: 用户={user_id}, 消息={payload.message_id}, emoji={payload.emoji}")
+            await self.message_handler.handle_reaction_event('reaction_remove', payload)
+
+        except Exception as e:
+            logger.error(f"处理reaction_remove事件时发生错误: {e}")
+            import traceback
+            logger.error(f"错误详情: {traceback.format_exc()}" )
+
+    def stop(self):
+        """停止reaction事件监听"""
+        self.is_running = False
+        logger.info("Reaction事件监听已停止")
+
+    def restart(self):
+        """重启reaction事件监听"""
+        logger.info("重启Reaction事件监听")
+        self.stop()
+        self.start()
+
+
 class BackgroundTaskManager:
     """后台任务管理器
     
@@ -233,12 +432,14 @@ class BackgroundTaskManager:
     
     Attributes:
         connection_monitor: 连接监控任务
+        reaction_event_task: reaction事件处理任务
         tasks: 所有注册的任务列表
     """
 
     def __init__(self):
         """初始化后台任务管理器"""
         self.connection_monitor: Optional[ConnectionMonitorTask] = None
+        self.reaction_event_task: Optional['ReactionEventTask'] = None
         self.tasks: list = []
         logger.debug("后台任务管理器初始化完成")
 
@@ -251,6 +452,17 @@ class BackgroundTaskManager:
         self.connection_monitor = ConnectionMonitorTask(client_manager)
         self.tasks.append(self.connection_monitor)
         logger.debug("连接监控任务已注册")
+
+    def register_reaction_event_task(self, client_manager, message_handler):
+        """注册reaction事件处理任务
+        
+        Args:
+            client_manager: Discord客户端管理器实例
+            message_handler: 消息处理器实例
+        """
+        self.reaction_event_task = ReactionEventTask(client_manager, message_handler)
+        self.tasks.append(self.reaction_event_task)
+        logger.debug("Reaction事件处理任务已注册")
 
     def start_all_tasks(self):
         """启动所有任务"""

--- a/src/recv_handler/discord_client.py
+++ b/src/recv_handler/discord_client.py
@@ -44,10 +44,12 @@ class DiscordClientManager:
         intents.guilds = discord_intents.get("guilds", True)
         intents.dm_messages = discord_intents.get("dm_messages", True)
         intents.message_content = discord_intents.get("message_content", True)
+        intents.reactions = discord_intents.get("reactions", True)  # 启用reaction权限
 
         logger.debug(
             f"Discord 权限意图: messages={intents.messages}, guilds={intents.guilds}, "
-            f"dm_messages={intents.dm_messages}, message_content={intents.message_content}"
+            f"dm_messages={intents.dm_messages}, message_content={intents.message_content}, "
+            f"reactions={intents.reactions}"
         )
 
         # 创建 Discord 客户端

--- a/src/recv_handler/emoji_mapping.py
+++ b/src/recv_handler/emoji_mapping.py
@@ -17,7 +17,7 @@ UNICODE_EMOJI_MAPPING = {
     "😉": ("眨眼", "wink"),
     "😊": ("微笑脸红", "blush"),
     "😇": ("天使笑", "innocent"),
-    
+
     # 爱心类
     "❤️": ("爱心", "heart"),
     "🧡": ("橙色心", "orange_heart"),
@@ -36,7 +36,7 @@ UNICODE_EMOJI_MAPPING = {
     "💓": ("心跳", "heartbeat"),
     "💞": ("旋转的心", "revolving_hearts"),
     "💝": ("心形礼物", "gift_heart"),
-    
+
     # 手势类
     "👍": ("赞", "thumbsup"),
     "👎": ("踩", "thumbsdown"),
@@ -57,7 +57,7 @@ UNICODE_EMOJI_MAPPING = {
     "🤚": ("抬手背", "raised_back_of_hand"),
     "🖐️": ("张开手掌", "hand_splayed"),
     "💪": ("肌肉/加油", "muscle"),
-    
+
     # 表情符号
     "😢": ("哭泣", "cry"),
     "😭": ("大哭", "sob"),
@@ -83,7 +83,7 @@ UNICODE_EMOJI_MAPPING = {
     "😫": ("疲惫", "tired_face"),
     "😩": ("厌倦", "weary"),
     "🥺": ("恳求", "pleading_face"),
-    
+
     # 符号类
     "✅": ("对勾/完成", "white_check_mark"),
     "❌": ("叉号/错误", "x"),
@@ -103,7 +103,7 @@ UNICODE_EMOJI_MAPPING = {
     "🥇": ("金牌", "first_place"),
     "🥈": ("银牌", "second_place"),
     "🥉": ("铜牌", "third_place"),
-    
+
     # 动物类
     "🐶": ("狗", "dog"),
     "🐱": ("猫", "cat"),
@@ -119,7 +119,7 @@ UNICODE_EMOJI_MAPPING = {
     "🐮": ("牛", "cow"),
     "🐷": ("猪", "pig"),
     "🐸": ("青蛙", "frog"),
-    
+
     # 食物类
     "🍕": ("披萨", "pizza"),
     "🍔": ("汉堡", "hamburger"),
@@ -137,7 +137,7 @@ UNICODE_EMOJI_MAPPING = {
     "🍫": ("巧克力", "chocolate_bar"),
     "🍬": ("糖果", "candy"),
     "🍭": ("棒棒糖", "lollipop"),
-    
+
     # 活动类
     "⚽": ("足球", "soccer"),
     "🏀": ("篮球", "basketball"),
@@ -152,7 +152,7 @@ UNICODE_EMOJI_MAPPING = {
     "💻": ("电脑", "computer"),
     "⌨️": ("键盘", "keyboard"),
     "🖱️": ("鼠标", "mouse_three_button"),
-    
+
     # 其他常用
     "💤": ("睡觉", "zzz"),
     "💭": ("思考泡泡", "thought_balloon"),
@@ -187,11 +187,11 @@ def get_emoji_meaning(emoji_str: str, emoji_name: str = None) -> tuple[str, str]
     # 优先查找Unicode emoji
     if emoji_str in UNICODE_EMOJI_MAPPING:
         return UNICODE_EMOJI_MAPPING[emoji_str]
-    
+
     # 查找自定义emoji
     if emoji_name and emoji_name in CUSTOM_EMOJI_MAPPING:
         return CUSTOM_EMOJI_MAPPING[emoji_name]
-    
+
     # 如果都找不到，返回原始名称
     display_name = emoji_name if emoji_name else emoji_str
     return (f"表情「{display_name}」", display_name)
@@ -210,7 +210,7 @@ def format_reaction_for_ai(emoji_str: str, emoji_name: str, count: int, user_nam
         str: 格式化后的文本描述
     """
     meaning, _ = get_emoji_meaning(emoji_str, emoji_name)
-    
+
     if count == 1:
         return f"用户{user_name}添加了{meaning}表情"
     else:

--- a/src/recv_handler/emoji_mapping.py
+++ b/src/recv_handler/emoji_mapping.py
@@ -1,0 +1,217 @@
+"""Emoji映射模块
+
+将Discord的emoji转换为AI可理解的中文含义
+"""
+
+# Unicode Emoji 到中文含义的映射
+UNICODE_EMOJI_MAPPING = {
+    # 笑脸类
+    "😀": ("开心大笑", "grinning"),
+    "😁": ("露齿笑", "grin"),
+    "😂": ("笑哭了", "joy"),
+    "🤣": ("笑翻了", "rofl"),
+    "😃": ("开心", "smiley"),
+    "😄": ("微笑", "smile"),
+    "😅": ("尴尬笑", "sweat_smile"),
+    "😆": ("眯眼笑", "laughing"),
+    "😉": ("眨眼", "wink"),
+    "😊": ("微笑脸红", "blush"),
+    "😇": ("天使笑", "innocent"),
+    
+    # 爱心类
+    "❤️": ("爱心", "heart"),
+    "🧡": ("橙色心", "orange_heart"),
+    "💛": ("黄色心", "yellow_heart"),
+    "💚": ("绿色心", "green_heart"),
+    "💙": ("蓝色心", "blue_heart"),
+    "💜": ("紫色心", "purple_heart"),
+    "🖤": ("黑色心", "black_heart"),
+    "🤍": ("白色心", "white_heart"),
+    "🤎": ("棕色心", "brown_heart"),
+    "💔": ("心碎", "broken_heart"),
+    "❤️‍🔥": ("燃烧的心", "heart_on_fire"),
+    "💕": ("两颗心", "two_hearts"),
+    "💖": ("闪亮心", "sparkling_heart"),
+    "💗": ("成长的心", "heartpulse"),
+    "💓": ("心跳", "heartbeat"),
+    "💞": ("旋转的心", "revolving_hearts"),
+    "💝": ("心形礼物", "gift_heart"),
+    
+    # 手势类
+    "👍": ("赞", "thumbsup"),
+    "👎": ("踩", "thumbsdown"),
+    "👏": ("鼓掌", "clap"),
+    "🙏": ("祈祷/感谢", "pray"),
+    "🤝": ("握手", "handshake"),
+    "👋": ("挥手", "wave"),
+    "✌️": ("胜利", "v"),
+    "🤞": ("祈愿", "crossed_fingers"),
+    "🤟": ("我爱你手势", "love_you_gesture"),
+    "🤘": ("摇滚手势", "metal"),
+    "👌": ("OK手势", "ok_hand"),
+    "👈": ("左指", "point_left"),
+    "👉": ("右指", "point_right"),
+    "👆": ("上指", "point_up_2"),
+    "👇": ("下指", "point_down"),
+    "✋": ("举手", "raised_hand"),
+    "🤚": ("抬手背", "raised_back_of_hand"),
+    "🖐️": ("张开手掌", "hand_splayed"),
+    "💪": ("肌肉/加油", "muscle"),
+    
+    # 表情符号
+    "😢": ("哭泣", "cry"),
+    "😭": ("大哭", "sob"),
+    "😤": ("生气", "triumph"),
+    "😠": ("愤怒", "angry"),
+    "😡": ("发怒", "rage"),
+    "🤬": ("爆粗口", "face_with_symbols_over_mouth"),
+    "😱": ("尖叫", "scream"),
+    "😨": ("恐惧", "fearful"),
+    "😰": ("焦虑", "cold_sweat"),
+    "😥": ("失望", "disappointed_relieved"),
+    "😓": ("冷汗", "sweat"),
+    "🤔": ("思考", "thinking"),
+    "🤨": ("挑眉", "raised_eyebrow"),
+    "😐": ("面无表情", "neutral_face"),
+    "😑": ("无语", "expressionless"),
+    "🙄": ("翻白眼", "eye_roll"),
+    "😏": ("得意", "smirk"),
+    "😒": ("不爽", "unamused"),
+    "😞": ("失望", "disappointed"),
+    "😔": ("沉思", "pensive"),
+    "😖": ("困惑", "confounded"),
+    "😫": ("疲惫", "tired_face"),
+    "😩": ("厌倦", "weary"),
+    "🥺": ("恳求", "pleading_face"),
+    
+    # 符号类
+    "✅": ("对勾/完成", "white_check_mark"),
+    "❌": ("叉号/错误", "x"),
+    "⭐": ("星星", "star"),
+    "🌟": ("闪亮星", "star2"),
+    "✨": ("闪光", "sparkles"),
+    "💫": ("晕眩", "dizzy"),
+    "🔥": ("火焰/热门", "fire"),
+    "💯": ("满分", "100"),
+    "⚡": ("闪电", "zap"),
+    "💥": ("爆炸", "boom"),
+    "🎉": ("庆祝", "tada"),
+    "🎊": ("五彩纸屑", "confetti_ball"),
+    "🎈": ("气球", "balloon"),
+    "🎁": ("礼物", "gift"),
+    "🏆": ("奖杯", "trophy"),
+    "🥇": ("金牌", "first_place"),
+    "🥈": ("银牌", "second_place"),
+    "🥉": ("铜牌", "third_place"),
+    
+    # 动物类
+    "🐶": ("狗", "dog"),
+    "🐱": ("猫", "cat"),
+    "🐭": ("鼠", "mouse"),
+    "🐹": ("仓鼠", "hamster"),
+    "🐰": ("兔子", "rabbit"),
+    "🦊": ("狐狸", "fox"),
+    "🐻": ("熊", "bear"),
+    "🐼": ("熊猫", "panda_face"),
+    "🐨": ("考拉", "koala"),
+    "🐯": ("老虎", "tiger"),
+    "🦁": ("狮子", "lion_face"),
+    "🐮": ("牛", "cow"),
+    "🐷": ("猪", "pig"),
+    "🐸": ("青蛙", "frog"),
+    
+    # 食物类
+    "🍕": ("披萨", "pizza"),
+    "🍔": ("汉堡", "hamburger"),
+    "🍟": ("薯条", "fries"),
+    "🌭": ("热狗", "hotdog"),
+    "🍿": ("爆米花", "popcorn"),
+    "🍩": ("甜甜圈", "doughnut"),
+    "🍪": ("饼干", "cookie"),
+    "🎂": ("蛋糕", "birthday"),
+    "🍰": ("蛋糕片", "cake"),
+    "🧁": ("纸杯蛋糕", "cupcake"),
+    "🍦": ("冰淇淋", "icecream"),
+    "🍧": ("刨冰", "shaved_ice"),
+    "🍨": ("冰淇淋", "ice_cream"),
+    "🍫": ("巧克力", "chocolate_bar"),
+    "🍬": ("糖果", "candy"),
+    "🍭": ("棒棒糖", "lollipop"),
+    
+    # 活动类
+    "⚽": ("足球", "soccer"),
+    "🏀": ("篮球", "basketball"),
+    "🎮": ("游戏", "video_game"),
+    "🎯": ("靶心", "dart"),
+    "🎲": ("骰子", "game_die"),
+    "🎸": ("吉他", "guitar"),
+    "🎹": ("钢琴", "musical_keyboard"),
+    "🎤": ("麦克风", "microphone"),
+    "🎧": ("耳机", "headphones"),
+    "📱": ("手机", "iphone"),
+    "💻": ("电脑", "computer"),
+    "⌨️": ("键盘", "keyboard"),
+    "🖱️": ("鼠标", "mouse_three_button"),
+    
+    # 其他常用
+    "💤": ("睡觉", "zzz"),
+    "💭": ("思考泡泡", "thought_balloon"),
+    "💬": ("对话泡泡", "speech_balloon"),
+    "👀": ("眼睛", "eyes"),
+    "🧠": ("大脑", "brain"),
+    "🫡": ("敬礼", "saluting_face"),
+    "🤡": ("小丑", "clown"),
+    "👻": ("鬼", "ghost"),
+    "💀": ("骷髅", "skull"),
+    "☠️": ("骷髅头", "skull_crossbones"),
+}
+
+# 自定义Emoji映射（服务器特定emoji）
+CUSTOM_EMOJI_MAPPING = {
+    # 这里可以添加服务器自定义emoji的映射
+    # 格式: "emoji_name": ("中文含义", "emoji_name")
+    # 例如: "pepe": ("佩佩蛙", "pepe")
+}
+
+
+def get_emoji_meaning(emoji_str: str, emoji_name: str = None) -> tuple[str, str]:
+    """获取emoji的中文含义
+    
+    Args:
+        emoji_str: emoji字符串（Unicode或自定义emoji的名称）
+        emoji_name: emoji名称（Discord提供的name字段）
+        
+    Returns:
+        tuple[str, str]: (中文含义, 英文名称)
+    """
+    # 优先查找Unicode emoji
+    if emoji_str in UNICODE_EMOJI_MAPPING:
+        return UNICODE_EMOJI_MAPPING[emoji_str]
+    
+    # 查找自定义emoji
+    if emoji_name and emoji_name in CUSTOM_EMOJI_MAPPING:
+        return CUSTOM_EMOJI_MAPPING[emoji_name]
+    
+    # 如果都找不到，返回原始名称
+    display_name = emoji_name if emoji_name else emoji_str
+    return (f"表情「{display_name}」", display_name)
+
+
+def format_reaction_for_ai(emoji_str: str, emoji_name: str, count: int, user_name: str) -> str:
+    """格式化reaction信息为AI可理解的文本
+    
+    Args:
+        emoji_str: emoji字符串
+        emoji_name: emoji名称
+        count: reaction数量
+        user_name: 用户名
+        
+    Returns:
+        str: 格式化后的文本描述
+    """
+    meaning, _ = get_emoji_meaning(emoji_str, emoji_name)
+    
+    if count == 1:
+        return f"用户{user_name}添加了{meaning}表情"
+    else:
+        return f"用户{user_name}添加了{meaning}表情（共{count}个）"

--- a/src/recv_handler/message_handler.py
+++ b/src/recv_handler/message_handler.py
@@ -4,14 +4,15 @@
 
 import base64
 import re
+import time
 import traceback
-from typing import List
+from typing import List, Optional
 import discord
 from maim_message import BaseMessageInfo, UserInfo, GroupInfo, FormatInfo, MessageBase, Seg
 from ..logger import logger
 from ..config import global_config
-from .emoji_mapping import format_reaction_for_ai
-
+from .emoji_mapping import get_emoji_meaning, format_reaction_for_ai
+from ..recv_handler.discord_client import discord_client
 
 class DiscordMessageHandler:
     """Discord 消息处理器
@@ -66,7 +67,7 @@ class DiscordMessageHandler:
             if self.router:
                 await self.router.send_message(maim_message)
                 logger.debug(f"已成功转发 Discord 消息到 MaiBot Core: {message.id}")
-                
+
                 # 更新发送处理器的上下文映射
                 if self.send_handler:
                     if (hasattr(message.channel, 'parent') and message.channel.parent is not None and
@@ -76,7 +77,7 @@ class DiscordMessageHandler:
                         thread_id = str(message.channel.id)
                         self.send_handler.update_thread_context(parent_channel_id, thread_id)
                         logger.debug(f"更新子区上下文映射: 父频道{parent_channel_id} -> 子区{thread_id}")
-                    elif (hasattr(message.channel, 'type') and 
+                    elif (hasattr(message.channel, 'type') and
                           message.channel.type == discord.ChannelType.text and
                           global_config.chat.inherit_channel_memory):
                         # 父频道消息：清除该频道的子区映射，确保回复发送到父频道
@@ -148,8 +149,8 @@ class DiscordMessageHandler:
                 if is_thread_message:
                     # Thread消息：根据配置决定是否继承父频道记忆
                     thread_name = message.channel.name
-                    parent_channel_name = (message.channel.parent.name 
-                                         if hasattr(message.channel.parent, 'name') 
+                    parent_channel_name = (message.channel.parent.name
+                                         if hasattr(message.channel.parent, 'name')
                                          else f"频道{message.channel.parent.id}")
 
                     if global_config.chat.inherit_channel_memory:
@@ -267,23 +268,6 @@ class DiscordMessageHandler:
                         logger.debug(f"处理Discord贴纸: {sticker.name}")
                 except (AttributeError, TypeError) as e:
                     logger.error(f"处理Discord贴纸失败: {e}")
-
-            # 处理Discord reactions（表情反应）
-            if message.reactions:
-                reaction_text_parts = []
-                for reaction in message.reactions:
-                    emoji_str = str(reaction.emoji)
-                    count = reaction.count
-                    reaction_text_parts.append(f"{emoji_str}×{count}")
-
-                if reaction_text_parts:
-                    reaction_text = f"[表情反应: {', '.join(reaction_text_parts)}]"
-                    # 如果已有文本内容，追加反应信息
-                    if message_segments and message_segments[-1].type == "text":
-                        message_segments[-1].data += f" {reaction_text}"
-                    else:
-                        message_segments.append(Seg(type="text", data=reaction_text))
-                    logger.debug(f"处理Discord表情反应: {len(message.reactions)}个反应")
 
             # 处理回复消息
             if message.reference and message.reference.message_id:
@@ -600,187 +584,267 @@ class DiscordMessageHandler:
             logger.error(f"处理回复上下文时发生错误: {e}")
             return f"[回复消息{message.reference.message_id}]，说："
 
-    async def handle_reaction_event(self, event_type: str, payload: discord.RawReactionActionEvent):
+    async def handle_reaction_event(
+        self,
+        event_type: str,
+        payload: discord.RawReactionActionEvent
+    ) -> None:
         """处理reaction事件
         
         Args:
-            event_type: 事件类型 ('reaction_add' 或 'reaction_remove')
+            event_type: 事件类型
             payload: Discord reaction事件数据
         """
         try:
             logger.debug(f"开始处理 {event_type} 事件:")
-            logger.debug(f"  消息ID: {payload.message_id}")
             logger.debug(f"  用户ID: {payload.user_id}")
+            logger.debug(f"  消息ID: {payload.message_id}")
+            logger.debug(f"  频道ID: {payload.channel_id}")
             logger.debug(f"  Emoji: {payload.emoji}")
-            
-            # 导入discord_client以获取频道和用户信息
-            from .discord_client import discord_client
+
+            # 转换为MaiBot消息格式
+            maim_message = await self._convert_reaction_to_maim(event_type, payload)
+            if not maim_message:
+                logger.warning("Reaction事件转换失败，跳过该事件")
+                return
+
+            logger.debug("Reaction事件转换成功，准备发送到 MaiBot Core")
+            logger.debug(f"  转换后平台: {maim_message.message_info.platform}")
+            logger.debug(f"  转换后消息ID: {maim_message.message_info.message_id}")
+
+            # 发送到 MaiBot Core
+            if self.router:
+                await self.router.send_message(maim_message)
+                action_text = "添加" if event_type == 'reaction_add' else "移除"
+                logger.info(
+                    f"已转发 {event_type} 事件到 MaiBot Core: "
+                    f"用户 {payload.user_id} {action_text}表情 {payload.emoji} "
+                    f"在消息 {payload.message_id} 上"
+                )
+            else:
+                logger.error("MaiBot 路由器未设置，无法转发 reaction 事件")
+
+        except Exception as e:
+            logger.error(f"处理 {event_type} 事件时发生错误: {e}")
+            logger.error(f"错误详情: {traceback.format_exc()}")
+
+    async def _convert_reaction_to_maim(
+        self,
+        event_type: str,
+        payload: discord.RawReactionActionEvent
+    ) -> Optional[MessageBase]:
+        """转换reaction事件为MaiBot消息格式"""
+        try:
+
+            # 获取Discord客户端
             client = discord_client.client
             if not client:
-                logger.warning("Discord客户端未初始化，忽略reaction事件")
-                return
-            
-            # 获取用户和成员信息
-            user: discord.abc.User | None = None
-            member: discord.Member | None = None
+                logger.error("Discord客户端未初始化")
+                return None
+
+            # 获取用户信息（优先获取Member以获取服务器昵称）
+            user = None
+            member = None
 
             if payload.member:
                 member = payload.member
                 user = payload.member
             else:
-                # 优先从 guild 中获取成员
+                # 从guild中获取member
                 guild = client.get_guild(payload.guild_id) if payload.guild_id else None
                 if guild:
                     member = guild.get_member(payload.user_id)
                     if not member:
                         try:
                             member = await guild.fetch_member(payload.user_id)
-                        except discord.NotFound:
-                            logger.warning(f"公会 {guild.id} 中找不到成员 {payload.user_id}")
-                        except discord.HTTPException as fetch_member_error:
-                            logger.error(f"获取成员 {payload.user_id} 信息失败: {fetch_member_error}")
+                        except (discord.NotFound, discord.HTTPException) as e:
+                            logger.warning(f"无法获取成员 {payload.user_id}: {e}")
 
-                if member:
-                    user = member
-                else:
-                    # 退回到用户级别
-                    try:
-                        user = await client.fetch_user(payload.user_id)
-                    except (discord.NotFound, discord.HTTPException) as fetch_user_error:
-                        logger.error(f"获取用户 {payload.user_id} 信息失败: {fetch_user_error}")
-                        return
+                    if member:
+                        user = member
+
+                # 如果无法获取member，退而求其次获取user
+                if not user:
+                    user = client.get_user(payload.user_id)
+                    if not user:
+                        try:
+                            user = await client.fetch_user(payload.user_id)
+                        except (discord.NotFound, discord.HTTPException) as e:
+                            logger.error(f"无法获取用户 {payload.user_id}: {e}")
+                            return None
 
             if not user:
-                logger.error(f"无法获取reaction用户 {payload.user_id} 的信息")
-                return
+                logger.error(f"无法获取用户 {payload.user_id} 的信息")
+                return None
 
-            user_id = user.id
-            # Discord API 提供 display_name 属性
-            user_display = getattr(user, "display_name", None) or user.name
+            # 构造用户信息
+            user_display_name = getattr(user, "display_name", None) or user.name
             server_nickname = getattr(member, "nick", None) if member else None
-            logger.debug(f"  用户: {user_display} (ID: {user_id})")
-            
-            # 获取频道信息
-            channel = client.get_channel(payload.channel_id)
-            if not channel:
-                try:
-                    channel = await client.fetch_channel(payload.channel_id)
-                except (discord.NotFound, discord.Forbidden):
-                    logger.warning(f"无法获取频道 {payload.channel_id}")
-                    return
-                except discord.HTTPException as fetch_channel_error:
-                    logger.error(f"获取频道 {payload.channel_id} 时发生错误: {fetch_channel_error}")
-                    return
-            
-            channel_name = channel.name if hasattr(channel, 'name') else 'DM'
-            
-            # 判断是否为子区
-            is_thread = isinstance(channel, discord.Thread)
-            
-            # 获取服务器信息
-            guild = client.get_guild(payload.guild_id) if payload.guild_id else None
-            guild_name = guild.name if guild else "私信"
-            
-            logger.debug(f"  频道: {channel_name} (ID: {payload.channel_id})")
-            logger.debug(f"  服务器: {guild_name}")
-            logger.debug(f"  是否子区: {is_thread}")
-            
-            platform_name = global_config.maibot_server.platform_name
 
-            # 构建用户信息
             user_info = UserInfo(
-                platform=platform_name,
-                user_id=str(user_id),
-                user_nickname=user_display,
+                platform=global_config.maibot_server.platform_name,
+                user_id=str(user.id),
+                user_nickname=user_display_name,
                 user_cardname=server_nickname
             )
 
-            # 构建群组信息
+            logger.debug(f"Reaction用户信息: {user_display_name} (ID: {user.id})")
+
+            # 构造群组信息
             group_info = None
-            if guild:
-                if is_thread:
+            guild_name = None
+            is_thread = False
+            thread_name = None
+
+            if payload.guild_id:
+                # 获取频道信息
+                channel = client.get_channel(payload.channel_id)
+                if not channel:
+                    try:
+                        channel = await client.fetch_channel(payload.channel_id)
+                    except (discord.NotFound, discord.HTTPException) as e:
+                        logger.warning(f"无法获取频道 {payload.channel_id}: {e}")
+                        channel = None
+
+                # 获取服务器信息
+                guild = client.get_guild(payload.guild_id)
+                if guild:
+                    guild_name = guild.name
+
+                # 判断是否为子区并构造群组信息
+                if channel and isinstance(channel, discord.Thread):
+                    is_thread = True
+                    thread_name = channel.name
                     parent_channel = getattr(channel, 'parent', None)
-                    parent_name = getattr(parent_channel, 'name', f"频道{parent_channel.id}" if parent_channel else channel_name)
-                    thread_name = getattr(channel, 'name', f"子区{channel.id}")
 
-                    if global_config.chat.inherit_channel_memory:
-                        group_id = str(parent_channel.id) if parent_channel else str(channel.id)
-                        display_name = f"[Reaction子区: {thread_name}] {parent_name} @ {guild_name}"
+                    if parent_channel and global_config.chat.inherit_channel_memory:
+                        # 子区继承父频道记忆模式
+                        channel_name = parent_channel.name
+                        group_id = str(parent_channel.id)
+                        group_name = f"[当前子区: {thread_name}] {channel_name}"
+                        if guild_name:
+                            group_name += f" @ {guild_name}"
+                        logger.debug(f"子区继承父频道记忆: {thread_name} -> 父频道ID {group_id}")
                     else:
+                        # 子区独立记忆模式
+                        channel_name = thread_name
                         group_id = str(channel.id)
-                        display_name = f"{thread_name} @ {guild_name}"
-
-                    group_info = GroupInfo(
-                        platform=platform_name,
-                        group_id=group_id,
-                        group_name=display_name
-                    )
+                        group_name = channel_name
+                        if parent_channel:
+                            group_name += f" [{parent_channel.name}]"
+                        if guild_name:
+                            group_name += f" @ {guild_name}"
+                        logger.debug(f"子区使用独立记忆: 子区ID={group_id}")
+                elif channel:
+                    # 普通频道
+                    channel_name = channel.name if hasattr(channel, 'name') else f"频道{channel.id}"
+                    group_id = str(channel.id)
+                    group_name = channel_name
+                    if guild_name:
+                        group_name += f" @ {guild_name}"
                 else:
-                    channel_display = getattr(channel, 'name', f"频道{channel.id}")
-                    group_info = GroupInfo(
-                        platform=platform_name,
-                        group_id=str(channel.id),
-                        group_name=f"{channel_display} @ {guild_name}"
-                    )
-            
-            # 获取emoji信息
+                    # 无法获取频道信息，使用频道ID
+                    group_id = str(payload.channel_id)
+                    group_name = f"频道{payload.channel_id}"
+                    if guild_name:
+                        group_name += f" @ {guild_name}"
+
+                group_info = GroupInfo(
+                    platform=global_config.maibot_server.platform_name,
+                    group_id=group_id,
+                    group_name=group_name
+                )
+                logger.debug(f"Reaction群组信息: {group_name} (ID: {group_id})")
+
+            # 获取并格式化emoji信息
             emoji = payload.emoji
             if emoji.is_unicode_emoji():
-                emoji_str = emoji.name  # Unicode emoji
+                emoji_str = emoji.name  # Unicode emoji直接使用name
                 emoji_name = None
             else:
-                # 自定义emoji
+                # 自定义emoji使用Discord格式
                 emoji_str = f"<:{emoji.name}:{emoji.id}>"
                 emoji_name = emoji.name
-            
-            logger.debug(f"  Emoji类型: {'Unicode' if emoji.is_unicode_emoji() else '自定义'}")
-            logger.debug(f"  Emoji值: {emoji_str}")
-            
-            # 格式化reaction描述
-            action_text = "添加了" if event_type == "reaction_add" else "移除了"
-            description = format_reaction_for_ai(emoji_str, emoji_name, 1, user_display)
-            # 调整描述文本
+
+            # 使用emoji_mapping获取emoji的含义
+            emoji_meaning, emoji_display = get_emoji_meaning(emoji_str, emoji_name)
+
+            logger.debug(f"Emoji信息: {emoji_str} -> {emoji_display} ({emoji_meaning})")
+            logger.debug(f"Emoji类型: {'Unicode' if emoji.is_unicode_emoji() else '自定义'}")
+
+            # 构造消息内容
+            action_text = "添加了" if event_type == 'reaction_add' else "移除了"
+
+
+            description = format_reaction_for_ai(emoji_str, emoji_name, 1, user_display_name)
+            # 调整描述文本以匹配实际操作
             description = description.replace("添加了", action_text)
-            
-            logger.debug(f"  格式化描述: {description}")
-            
-            # 构建notify类型消息段
-            notify_data = {
-                "type": "reaction",
-                "action": "add" if event_type == "reaction_add" else "remove",
+
+            logger.debug(f"格式化描述: {description}")
+
+            # 构造消息段列表
+            message_segments = []
+
+            # 添加文本说明段
+            message_segments.append(Seg(type="text", data=description))
+
+            # 添加reaction元数据段（供MaiBot Core和插件使用）
+            reaction_metadata = {
+                "event_type": event_type,
+                "action": "add" if event_type == 'reaction_add' else "remove",
+                "user_id": str(payload.user_id),
+                "user_name": user_display_name,
                 "message_id": str(payload.message_id),
+                "channel_id": str(payload.channel_id),
+                "guild_id": str(payload.guild_id) if payload.guild_id else None,
                 "emoji": emoji_str,
-                "description": description
+                "emoji_name": emoji_name,
+                "emoji_display": emoji_display,
+                "emoji_meaning": emoji_meaning,
+                "is_thread": is_thread,
+                "thread_name": thread_name if is_thread else None,
             }
-            
-            notify_seg = Seg(type="notify", data=notify_data)
-            
-            # 构建 BaseMessageInfo
-            base_message_info = BaseMessageInfo(
-                platform=platform_name,
+            message_segments.append(Seg(type="reaction_event", data=reaction_metadata))
+
+            # 构造格式信息
+            format_info = FormatInfo(
+                content_format=["text", "reaction_event"],
+                accept_format=[
+                    "text", "image", "emoji", "reply", "voice", "command",
+                    "file", "video", "reaction"
+                ]
+            )
+
+            # 构造唯一消息ID（使用原始消息ID、用户ID、事件类型和时间戳的组合）
+            timestamp = int(time.time() * 1000)  # 毫秒级时间戳确保唯一性
+            unique_message_id = f"reaction_{payload.message_id}_{payload.user_id}_{event_type}_{timestamp}"
+
+            # 构造消息元数据
+            message_info = BaseMessageInfo(
+                platform=global_config.maibot_server.platform_name,
+                message_id=unique_message_id,
+                time=time.time(),
                 user_info=user_info,
                 group_info=group_info,
-                format_info=FormatInfo()
+                format_info=format_info
             )
-            
-            # 构建完整的 MessageBase
-            maim_message = MessageBase(
-                message_info=base_message_info,
-                message_segment=notify_seg,
+
+            # 构造完整消息段
+            if len(message_segments) == 1:
+                message_segment = message_segments[0]
+            else:
+                message_segment = Seg(type="seglist", data=message_segments)
+
+            return MessageBase(
+                message_info=message_info,
+                message_segment=message_segment,
                 raw_message=description
             )
-            
-            # 发送到MaiBot Core
-            if self.router:
-                logger.debug(f"发送reaction事件到MaiBot: {description}")
-                await self.router.send_message(maim_message)
-                logger.debug("Reaction事件已成功发送到MaiBot")
-            else:
-                logger.error("Router未初始化，无法发送reaction事件")
-                
-        except Exception as e:  # pylint: disable=broad-except
-            logger.error(f"处理reaction事件时发生错误: {e}")
+
+        except Exception as e:
+            logger.error(f"转换 reaction 事件时发生错误: {e}")
             logger.error(f"错误详情: {traceback.format_exc()}")
+            return None
 
 
 # 创建全局消息处理器实例

--- a/src/send_handler/main_send_handler.py
+++ b/src/send_handler/main_send_handler.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import traceback
+
 from typing import List, Optional, Sequence
 
 import discord
@@ -11,7 +13,7 @@ from maim_message import BaseMessageInfo, MessageBase, Seg
 from ..logger import logger
 from .message_send_handler import DiscordContentBuilder
 from .thread_send_handler import ThreadRoutingManager
-
+from ..recv_handler.discord_client import discord_client
 
 class DiscordSendHandler:
     """MaiBot 到 Discord 的消息调度器。
@@ -120,10 +122,10 @@ class DiscordSendHandler:
         """
         segment = message.message_segment
         command_data = segment.data if hasattr(segment, 'data') else {}
-        
         # 检查是否为 reaction 命令
         command_type = command_data.get('type', '')
-        
+
+        # 处理reaction命令
         if command_type == 'reaction':
             await self._handle_reaction_command(message, command_data)
         else:
@@ -133,7 +135,7 @@ class DiscordSendHandler:
         """处理 reaction 命令（添加或移除表情）
         
         Args:
-            _message: MaiBot 消息对象（未使用）
+            _message: MaiBot 消息对象
             command_data: 命令数据，包含:
                 - action: 'add' 或 'remove'
                 - message_id: 目标消息ID
@@ -148,15 +150,16 @@ class DiscordSendHandler:
             target_message_id = command_data.get('message_id')
             channel_id = command_data.get('channel_id')
             emoji_str = command_data.get('emoji')
-            
             if not target_message_id or not channel_id or not emoji_str:
-                logger.error(f"Reaction命令缺少必要参数: {command_data}")
+                logger.error(f"Reaction命令缺少必要参数，需要 message_id、channel_id 和 emoji: {command_data}")
                 return
 
-            logger.debug(f"处理reaction命令: action={action}, message_id={target_message_id}, emoji={emoji_str}")
+            logger.debug(
+                f"处理reaction命令: action={action}, "
+                f"message_id={target_message_id}, emoji={emoji_str}"
+            )
 
             # 获取 Discord 客户端
-            from ..recv_handler.discord_client import discord_client
             client = discord_client.client
             if not client or not getattr(client, 'user', None):
                 logger.error("Discord客户端未就绪，无法执行reaction命令")
@@ -165,8 +168,8 @@ class DiscordSendHandler:
             try:
                 channel_id_int = int(channel_id)
                 message_id_int = int(target_message_id)
-            except (TypeError, ValueError):
-                logger.error(f"Reaction命令的消息或频道ID格式不正确: {command_data}")
+            except (TypeError, ValueError) as e:
+                logger.error(f"Reaction命令的消息或频道ID格式不正确: {command_data}, 错误: {e}")
                 return
 
             # 获取频道
@@ -174,23 +177,26 @@ class DiscordSendHandler:
             if not channel:
                 try:
                     channel = await client.fetch_channel(channel_id_int)
-                except (discord.NotFound, discord.Forbidden):
-                    logger.error(f"无法找到频道: {channel_id_int}")
+                except (discord.NotFound, discord.Forbidden) as e:
+                    logger.error(f"无法找到频道 {channel_id_int}: {e}")
                     return
-                except discord.HTTPException as fetch_error:
-                    logger.error(f"获取频道 {channel_id_int} 时发生错误: {fetch_error}")
+                except discord.HTTPException as e:
+                    logger.error(f"获取频道 {channel_id_int} 时发生错误: {e}")
                     return
 
             # 获取消息
             try:
                 target_message = await channel.fetch_message(message_id_int)
             except discord.NotFound:
-                logger.error(f"无法找到消息: {message_id_int}")
+                logger.error(f"无法找到消息 {message_id_int}")
                 return
             except discord.Forbidden:
-                logger.error(f"没有权限访问消息: {message_id_int}")
+                logger.error(f"没有权限访问消息 {message_id_int}")
                 return
-            
+            except discord.HTTPException as e:
+                logger.error(f"获取消息 {message_id_int} 时发生错误: {e}")
+                return
+
             # 执行添加或移除 reaction
             if action == 'add':
                 await target_message.add_reaction(emoji_str)
@@ -200,14 +206,14 @@ class DiscordSendHandler:
                 logger.info(f"成功从消息 {message_id_int} 移除表情: {emoji_str}")
             else:
                 logger.warning(f"未知的reaction操作: {action}")
-                
         except discord.HTTPException as e:
-            logger.error(f"执行reaction命令时发生HTTP错误: {e}")
+            logger.error(f"执行reaction命令时发生Discord HTTP错误: {e}")
+            logger.error(f"错误详情: {traceback.format_exc()}")
         except (ValueError, AttributeError) as e:
-            logger.error(f"执行reaction命令时发生错误: {e}")
+            logger.error(f"执行reaction命令时发生参数错误: {e}")
+            logger.error(f"错误详情: {traceback.format_exc()}")
         except Exception as e:
             logger.error(f"执行reaction命令时发生未知错误: {e}")
-            import traceback
             logger.error(f"错误详情: {traceback.format_exc()}")
 
     async def _handle_notify(self, message: MessageBase) -> None:


### PR DESCRIPTION
## Sourcery 总结

增加对 Discord 反应事件的全面支持并增强连接可靠性。引入一个新的 ReactionEventTask，用于订阅原始的反应添加/移除事件，通过表情符号映射模块进行翻译，并将其转发到 MaiBot 核心。扩展发送处理器以处理反应命令。重构连接监视器，使其包含周期性主动健康检查和自动重连功能，并简化主消息处理管道。

新功能：
- 添加 ReactionEventTask 以监听和处理原始的 Discord 反应添加/移除事件
- 在 DiscordMessageHandler 中实现 handle_reaction_event，将反应事件转换为 MaiBot 消息格式
- 在 DiscordSendHandler 中支持反应添加/移除命令
- 引入 emoji_mapping 模块，用于将表情符号翻译成中文含义

改进：
- 增强 ConnectionMonitorTask，使其具备周期性主动健康检查和连续失败后的自动重连功能
- 使用 tasks.loop(reconnect=True) 简化连接监视器循环并改进超时处理
- 重构主消息管道，直接使用 discord_client.message_queue 并移除单独的收集器
- 扩展 BackgroundTaskManager 以注册反应任务并在客户端重置时自动重新注册事件处理器
- 在客户端配置中启用 Discord 反应意图

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add comprehensive support for Discord reaction events and enhance connection reliability. Introduce a new ReactionEventTask to subscribe to raw reaction add/remove events, translate them via an emoji mapping module, and forward them to MaiBot core. Extend the send handler to process reaction commands. Refactor the connection monitor to include periodic active health checks with automatic reconnect and streamline the main message processing pipeline.

New Features:
- Add ReactionEventTask to listen for and handle raw Discord reaction add/remove events
- Implement handle_reaction_event in DiscordMessageHandler to convert reaction events to MaiBot message format
- Support reaction add/remove commands in DiscordSendHandler
- Introduce emoji_mapping module for translating emojis to Chinese meanings

Enhancements:
- Augment ConnectionMonitorTask with periodic active health checks and automatic reconnect after consecutive failures
- Simplify connection monitor loop using tasks.loop(reconnect=True) and improved timeout handling
- Refactor main message pipeline to use discord_client.message_queue directly and remove the separate collector
- Extend BackgroundTaskManager to register reaction tasks and auto-reregister event handlers on client reset
- Enable Discord reaction intents in the client configuration

</details>